### PR TITLE
Feat: support density fitting

### DIFF
--- a/pbe/misc.py
+++ b/pbe/misc.py
@@ -1,7 +1,7 @@
 import numpy, os
 from pyscf import gto, scf
 
-def libint2pyscf(xyzfile, hcore, basis, hcore_skiprows=1):
+def libint2pyscf(xyzfile, hcore, basis, hcore_skiprows=1, use_df=False):
     """Build a pyscf Mole and RHF object using the given xyz file and core Hamiltonian (in libint standard format)
 
     c.f.
@@ -36,6 +36,8 @@ def libint2pyscf(xyzfile, hcore, basis, hcore_skiprows=1):
         Name of the basis set
     hcore_skiprows : int, optional
         # of first rows to skip from the core Hamiltonian file, by default 1
+    use_df : boolean, optional
+        If true, use density-fitting to evaluate the two-electron integrals
 
     Returns
     -------
@@ -63,6 +65,10 @@ def libint2pyscf(xyzfile, hcore, basis, hcore_skiprows=1):
 
     mol.incore_anyway = True
     mf = scf.RHF(mol)
+    if use_df:
+        from pyscf import df
+        mydf = df.DF(mol).build()
+        mf.with_df = mydf
     mf.get_hcore = lambda *args: hcore_pyscf
 
     return mol, mf

--- a/pbe/pbe.py
+++ b/pbe/pbe.py
@@ -255,7 +255,8 @@ class pbe:
                       frag_type=self.frag_type)
                 
             if not restart:
-                eri = ao2mo.incore.full(eri_, fobjs_.TA, compact=True)                    
+                if eri_ is None and not self.mf.with_df is None: eri = ao2mo.kernel(self.mf.mol, fobjs_.TA, compact=True) # for density-fitted integrals; if mf is provided, pyscf.ao2mo uses DF object in an outcore fashion
+                else: eri = ao2mo.incore.full(eri_, fobjs_.TA, compact=True) # otherwise, do an incore ao2mo
                 #if fobjs_.dname in eri:
                 #    del(file_eri[fobjs_.dname])
                 


### PR DESCRIPTION
`libint2pyscf` takes `use_df` as kwarg, `pbe` uses df for `ao2mo` if df is provided.