### PR TITLE
Adding fragment-by-fragment energy evaluation, without all rdms, for …

### DIFF
--- a/pbe/pbe.py
+++ b/pbe/pbe.py
@@ -309,24 +309,24 @@ class pbe:
             fobj.udim = couti
             couti = fobj.set_udim(couti)
                         
-    def oneshot(self, solver='MP2',nproc=1, ompnum=4):
+    def oneshot(self, solver='MP2', nproc=1, ompnum=4, calc_frag_energy=False):
         from .solver import be_func
         from .be_parallel import be_func_parallel
 
-
+        print("Calculating Energy by Fragment? ", calc_frag_energy)
         if nproc == 1:
-            E = be_func(None, self.Fobjs, self.Nocc, solver, self.enuc,
+            rets  = be_func(None, self.Fobjs, self.Nocc, solver, self.enuc, hf_veff=self.hf_veff,
                         hci_cutoff=self.hci_cutoff,
                         ci_coeff_cutoff = self.ci_coeff_cutoff,
                         select_cutoff = self.select_cutoff,
-                        nproc=ompnum,
+                        nproc=ompnum, frag_energy=calc_frag_energy,
                         ereturn=True, eeval=True)
         else:
-            E = be_func_parallel(None, self.Fobjs, self.Nocc, solver, self.enuc,
+            rets  = be_func_parallel(None, self.Fobjs, self.Nocc, solver, self.enuc, hf_veff=self.hf_veff,
                                  hci_cutoff=self.hci_cutoff,
                                  ci_coeff_cutoff = self.ci_coeff_cutoff,
                                  select_cutoff = self.select_cutoff,
-                                 ereturn=True, eeval=True,
+                                 ereturn=True, eeval=True, frag_energy=calc_frag_energy,
                                  nproc=nproc, ompnum=ompnum)
 
         print('-----------------------------------------------------',
@@ -336,10 +336,15 @@ class pbe:
         print('-----------------------------------------------------',
                   flush=True)
         print(flush=True)
+        if calc_frag_energy:
+            print("Final Tr(F del g) is         : {:>12.8f} Ha".format(rets[1][0]+rets[1][2]), flush=True)
+            print("Final Tr(V K_approx) is      : {:>12.8f} Ha".format(rets[1][1]), flush=True)
+            print("Final e_corr is              : {:>12.8f} Ha".format(rets[0]), flush=True)
 
-            
-        self.get_rdm(approx_cumulant=True, return_rdm=False)
+            self.ebe_tot = rets[0]
 
+        if not calc_frag_energy:
+            self.get_rdm(approx_cumulant=True, return_rdm=False)
 
 
     def update_fock(self, heff=None):

--- a/pbe/rdm.py
+++ b/pbe/rdm.py
@@ -1,5 +1,15 @@
 import numpy, sys, scipy
 
+def compute_energy_wo_fullrdm(self, return_ao, print_energy=True):
+    from pyscf import scf, ao2mo
+
+    if not self.molecule:
+        print(' compute_energy_full() only works for molecules, exiting', flush=True)
+        sys.exit()
+    for fobjs in self.Fobjs:
+        cind = [ fobjs.fsites[i] for i in fobjs.efac[1]]
+
+
 def rdm1_fullbasis(self, return_ao=True, only_rdm1=False, only_rdm2=False, return_lo=False, return_RDM2=True, print_energy=False):
     from pyscf import scf, ao2mo
     


### PR DESCRIPTION
Add a version of oneshot that allows us to calculate the energy of the system on a by-fragment basis, so that we do not have to construct full rdms, for big systems. Tested for oneshot calculations of different BE levels using CCSD, with and without frozen core, in series and parallel, and different molecule types, turning on and off full rdm construction