### PR TITLE
Enable an automatic installation of the libdmet dependency + account for fixed bug in get_emb_eri_fast_gdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,9 @@ processors.
 - PySCF library
 - Numpy
 - Scipy
-- libDMET<sup>##</sup> (required for periodic BE)
+- libDMET (required for periodic BE)
 - [Wannier90](https://github.com/wannier-developers/wannier90)<sup>&&</sup> (to use Wannier functions)
 
-<sub><sup>##</sup>The modified version of [libDMET](https://github.com/gkclab/libdmet_preview) available
-at [here](https://github.com/oimeitei/libdmet_preview) is
-recommended to run periodic BE using QuEmb.
 <sup>&&</sup>Wannier90 code is interfaced via [libDMET](https://github.com/gkclab/libdmet_preview) in QuEmb</sub>
 
 ### Steps

--- a/kbe/pbe.py
+++ b/kbe/pbe.py
@@ -367,7 +367,7 @@ class BE:
                     eri = get_emb_eri_fast_gdf(self.mf.cell, self.mf.with_df,
                                                t_reversal_symm=True,
                                                symmetry=4,
-                                               C_ao_emb=fobjs_.TA)[0]
+                                               C_ao_eo=fobjs_.TA)[0]
 
                     file_eri.create_dataset(fobjs_.dname, data=eri)
                     eri = ao2mo.restore(8, eri, fobjs_.nao)
@@ -638,7 +638,7 @@ def eritransform_parallel(a, atom, basis, kpts, C_ao_emb, cderi):
     mydf._cderi = cderi
     eri = get_emb_eri_fast_gdf(cell, mydf,
             t_reversal_symm=True, symmetry=4,
-            C_ao_emb = C_ao_emb)
+            C_ao_eo=C_ao_emb)
 
     return eri
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest==8.3.2
 # is merged, let it point to the original libdmet
 # https://github.com/gkclab/libdmet_preview
 libdmet @ git+https://github.com/mcocdawc/libdmet_preview.git@add_fixes_for_BE
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 pyscf==2.6.2
 pytest==8.3.2
-
+# TODO this temporarily points to mcocdawc/libdmet_preview.
+# as soon as this PR: https://github.com/gkclab/libdmet_preview/pull/21
+# is merged, let it point to the original libdmet
+# https://github.com/gkclab/libdmet_preview
+libdmet @ git+https://github.com/mcocdawc/libdmet_preview.git@add_fixes_for_BE

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,10 @@ setup(
         'numpy>=1.22.0',
         'scipy>=1.7.0',
         'pyscf>=2.0.0',
+        # TODO this temporarily points to mcocdawc/libdmet_preview.
+        # as soon as this PR: https://github.com/gkclab/libdmet_preview/pull/21
+        # is merged, let it point to the original libdmet
+        # https://github.com/gkclab/libdmet_preview
+        'libdmet @ git+https://github.com/mcocdawc/libdmet_preview.git@add_fixes_for_BE'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'numpy>=1.22.0',
         'scipy>=1.7.0',
         'pyscf>=2.0.0',
+        'matplotlib'
         # TODO this temporarily points to mcocdawc/libdmet_preview.
         # as soon as this PR: https://github.com/gkclab/libdmet_preview/pull/21
         # is merged, let it point to the original libdmet

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'numpy>=1.22.0',
         'scipy>=1.7.0',
         'pyscf>=2.0.0',
-        'matplotlib'
+        'matplotlib',
         # TODO this temporarily points to mcocdawc/libdmet_preview.
         # as soon as this PR: https://github.com/gkclab/libdmet_preview/pull/21
         # is merged, let it point to the original libdmet

--- a/tests/chem_dm_kBE_test.py
+++ b/tests/chem_dm_kBE_test.py
@@ -1,5 +1,5 @@
 """
-This script tests the period BE1 and BE2 workflows using chemical potential and density matching, respectively. 
+This script tests the period BE1 and BE2 workflows using chemical potential and density matching, respectively.
 Also tests the gaussian density fitting interface, which is typically used by default.
 
 Author(s): Shaun Weatherly
@@ -14,7 +14,7 @@ class Test_kBE_Full(unittest.TestCase):
         import libdmet
     except ImportError:
         libdmet = None
-    
+
     @unittest.skipIf(libdmet is None, "Module `libdmet` not imported correctly.")
     def test_kc2_sto3g_be1_chempot(self):
         kpt = [1, 1, 1]
@@ -39,7 +39,6 @@ class Test_kBE_Full(unittest.TestCase):
 
         self.periodic_test(cell, kpt, 'be1', 'C2 (kBE1)', 'autogen', -74.62798837, only_chem = True)
 
-    @unittest.skipIf(os.getenv("GITHUB_ACTIONS") == "true", "Skip expensive tests on Github Actions")
     def test_kc4_sto3g_be2_density(self):
         kpt = [1, 1, 1]
         cell = gto.Cell()
@@ -64,25 +63,25 @@ class Test_kBE_Full(unittest.TestCase):
         self.periodic_test(cell, kpt, 'be2', 'C4 (kBE2)', 'autogen', -149.37047888, only_chem = False)
 
     def periodic_test(self, cell, kpt, be_type, test_name, frag_type, target, delta = 1e-4, only_chem = True):
-        
+
         kpts = cell.make_kpts(kpt, wrap_around=True)
         mydf = df.GDF(cell, kpts)
         mydf.build()
-        
+
         kmf = scf.KRHF(cell, kpts)
         kmf.with_df = mydf
         kmf.exxdiv = None
         kmf.conv_tol = 1e-12
         kmf.kernel()
-        
-        kfrag = fragpart(be_type=be_type, 
+
+        kfrag = fragpart(be_type=be_type,
                          mol=cell,
                          frag_type=frag_type,
-                         kpt=kpt, 
+                         kpt=kpt,
                          frozen_core=True)
         mykbe = BE(kmf, kfrag, kpts=kpts)
         mykbe.optimize(solver='CCSD', only_chem=only_chem)
-        
+
         self.assertAlmostEqual(mykbe.ebe_tot, target,
                                msg = "kBE Correlation Energy for " + test_name
                                + " does not match the expected correlation energy!", delta = delta)

--- a/tests/chem_dm_kBE_test.py
+++ b/tests/chem_dm_kBE_test.py
@@ -37,7 +37,7 @@ class Test_kBE_Full(unittest.TestCase):
         cell.verbose=0
         cell.build()
 
-        self.periodic_test(cell, kpt, 'be1', 'C2 (kBE1)', 'autogen', -74.62798837, only_chem = True)
+        self.periodic_test(cell, kpt, 'be1', 'C2 (kBE1)', 'autogen', -74.64695833012868, only_chem = True)
 
     def test_kc4_sto3g_be2_density(self):
         kpt = [1, 1, 1]
@@ -60,7 +60,7 @@ class Test_kBE_Full(unittest.TestCase):
         cell.verbose=0
         cell.build()
 
-        self.periodic_test(cell, kpt, 'be2', 'C4 (kBE2)', 'autogen', -149.37047888, only_chem = False)
+        self.periodic_test(cell, kpt, 'be2', 'C4 (kBE2)', 'autogen', -149.4085332249809, only_chem = False)
 
     def periodic_test(self, cell, kpt, be_type, test_name, frag_type, target, delta = 1e-4, only_chem = True):
 


### PR DESCRIPTION
- currently points to my fork of libdmet which made the library pip-installable. As soon as PRs https://github.com/gkclab/libdmet_preview/pull/20 and https://github.com/gkclab/libdmet_preview/pull/21 are merged, we can get rid of custom libdmet versions and just use their library
- this will now enable testing of the periodic BE code, e.g. chem_dm_kBE_test.py
- Unfortunately there was a bug in the previous custom libdmet https://github.com/oimeitei/libdmet_preview/blob/main/libdmet/basis_transform/eri_transform.py#L296 
```python3
C_ao_emb = C_ao_emb[np.newaxis]/(nkpts*(0.75))
# should actually be 
C_ao_emb = C_ao_emb[np.newaxis] / (nkpts**(0.75))
```
- this means that the test suite will fail now (as it should)